### PR TITLE
Template for ML benchmark datasets

### DIFF
--- a/data/PASTIS.md
+++ b/data/PASTIS.md
@@ -1,0 +1,81 @@
+# Panoptic Agricultural Satellite TIme-Series (PASTIS)
+
+## Submission Details
+
+- **Submitter (Affiliation):** Hannah Kerner
+- **Data Provider (Legal Entity):** Vivien St Faire Garnot
+- **Homepage:** https://github.com/VSainteuf/pastis-benchmark
+
+## Overview
+
+PASTIS is a benchmark dataset for panoptic and semantic segmentation of agricultural parcels from satellite time series. 
+It contains 2,433 patches within the French metropolitan territory with panoptic annotations (instance index + semantic label for each pixel). 
+Each patch is a Sentinel-2 multispectral image time series of variable length.
+
+## Data
+
+<!-- Any important information about your ML benchmark field boundary dataset and metadata,
+e.g. what satellite datasets were used. -->
+
+- **URL:** https://zenodo.org/record/5012942 
+- **Documentation:** https://github.com/VSainteuf/pastis-benchmark/blob/main/documentation/pastis-documentation.pdf
+- **File Format:** Numpy files
+- **Geographic Coverage:** France (~4000 km2 sampled from four regions)
+- **Has Train/Test split?:** Yes
+- **Input data sensor(s):** Sentinel-2
+- **Input patch size:** 128x128 pixels
+- **Input data channels(s):** The 10 channels correspond to the non-atmospheric spectral bands of the Sentinel-2 satellite, after atmospheric correction and re-sampling at a spatial resolution of 10 meters per pixel.
+- **Input data timesteps:** Variable length (30-60, all available Sentinel-2 acquisitions)
+- **Label information:**
+  - [ ] Semantic segmentation (binary masks)
+  - [ ] Instance segmentation (instance masks)
+  - [x] Panoptic segmentation (full-coverage instance masks)
+  - [x] Includes crop type or category labels: 18 crop types plus a background class
+  - [ ] Ground truth polygons (vector data used to create label masks)
+- **Projection (if georeferenced):** N/A
+- **License:** MIT License
+- **Data Creation Details:** [Garnot et al., ICCV 2021](https://openaccess.thecvf.com/content/ICCV2021/papers/Garnot_Panoptic_Segmentation_of_Satellite_Image_Time_Series_With_Convolutional_Temporal_ICCV_2021_paper.pdf)
+- **Label Source:** [France Graphical Plot Register (RPG)](https://www.data.gouv.fr/fr/datasets/registre-parcellaire-graphique-rpg-contours-des-parcelles-et-ilots-culturaux-et-leur-groupe-de-cultures-majoritaire/)
+
+...
+
+### Metadata
+Splits used for 5-fold cross validation
+
+### Dataset splits
+Recommends using 5-fold cross validation rather than a single train/test split.
+
+**Type of split:** 5-fold CV split uniform at random by patch
+
+| Subset | # samples |
+| ----- | -------- |
+| Total | 2,433 |
+| Train | n/a |
+| Validation | n/a |
+| Test | n/a |
+
+### SOTA performance
+
+<!-- If the dataset was published with state-of-the-art (SOTA) performance for benchmarking, include those metrics here. -->
+
+| Model | OA | F1 | IoU | mAP |
+| ----- | -- | -- | --- | --- |
+| TSViT | 83.4%	|  | 65.4% | | |
+
+### Example
+
+![pastis](https://github.com/VSainteuf/pastis-benchmark/raw/main/images/predictions.png)
+
+## API (optional)
+
+<!-- If the dataset provides an API, python package, or other software for loading the dataset, 
+include details about it here. -->
+
+| Library/package | URL | 
+| -------- | --- |
+| Github repo | https://github.com/VSainteuf/pastis-benchmark |
+| TorchGeo | https://torchgeo.readthedocs.io/en/stable/_modules/torchgeo/datasets/pastis.html | 
+
+### Example
+
+https://github.com/VSainteuf/pastis-benchmark/blob/main/demo.ipynb

--- a/template-mlbenchmark.md
+++ b/template-mlbenchmark.md
@@ -21,13 +21,24 @@ e.g. what satellite datasets were used. -->
 - **Geographic Coverage:** India, Ghana, etc.
 - **Has Train/Test split?:** Yes/No
 - **Input data sensor(s):** Sentinel-2, Sentinel-1, PlanetScope, etc.
+- **Input patch size:** e.g., 256x256 pixels
 - **Input data channels(s):** RGB, NIR, VV/VH, etc. Include number of channels.
 - **Input data timesteps:** 1, 12 (monthly), 2 (seasonally), etc.
-- **Projection:** EPSG:4326/...
+- **Label information:**
+  - [ ] Semantic segmentation (binary masks)
+  - [ ] Instance segmentation (instance masks)
+  - [ ] Panoptic segmentation (complete-image instance masks)
+  - [ ] Includes crop type or category labels
+  - [ ] Ground truth polygons (vector data used to create label masks)
+- **Projection (if georeferenced):** EPSG:4326/...
 - **License:** CC-0/Commercial/...
 - **Data Creation Details:** Publication or other source of information about how dataset was constructed
-
+- **Label Source:** Dataset of original ground truth labels used to create this dataset (may be a link to the dataset file in this repo)
+  
 ...
+
+### Metadata
+<!-- Describe any metadata provided with the samples, if available. -->
 
 ### Dataset splits
 <!-- Include details about the dataset splits, if available. -->
@@ -36,6 +47,7 @@ e.g. what satellite datasets were used. -->
 
 | Subset | # samples |
 | ----- | -------- |
+| Total | integer |
 | Train | integer |
 | Validation | integer |
 | Test | integer |
@@ -44,22 +56,22 @@ e.g. what satellite datasets were used. -->
 
 <!-- If the dataset was published with state-of-the-art (SOTA) performance for benchmarking, include those metrics here. -->
 
-| Model | F1 score | IoU | mAP |
-| ----- | -------- | --- | --- |
-| name | 0-100 | 0-100 | 0-100 |
+| Model | OA | F1 | IoU | mAP |
+| ----- | -- | -- | --- | --- |
+| name | 0-100 | 0-100 | 0-100 | 0-100 |
 
 ### Example
 
-<!-- Please provide a link to the data or embed it into this document as a code block. -->
+<!-- Please provide a representative image to visualize the data, if available. -->
 
 ## API (optional)
 
 <!-- If the dataset provides an API, python package, or other software for loading the dataset, 
 include details about it here. -->
 
-| Library/package | URL | Documentation |
-| -------- | --- | ------------- |
-| Library name | https://data.example/api/ | https://data.example/api/docs/ |
+| Library/package | URL |
+| -------- | --- |
+| Library name | https://data.example/api/ |
 
 ### Example
 

--- a/template-mlbenchmark.md
+++ b/template-mlbenchmark.md
@@ -1,0 +1,66 @@
+# Title <!-- Replace with your title of the dataset -->
+
+## Submission Details
+
+- **Submitter (Affiliation):** John Doe, Example Corp.
+- **Data Provider (Legal Entity):** Field Data, Inc. (Company/Government/Individual/Other)
+- **Homepage:** https://homepage.example/data
+
+## Overview
+
+<!-- Please provide a short overview about your data and/or API. -->
+
+## Data
+
+<!-- Any important information about your ML benchmark field boundary dataset and metadata,
+e.g. what satellite datasets were used. -->
+
+- **URL:** https://data.example/files/ (does not need to be the whole dataset, can just be a couple rows of representative data)
+- **Documentation:** https://docs.data.example
+- **File Format:** GeoTIFF, JPEG, Numpy arrays, etc.
+- **Geographic Coverage:** India, Ghana, etc.
+- **Has Train/Test split?:** Yes/No
+- **Input data sensor(s):** Sentinel-2, Sentinel-1, PlanetScope, etc.
+- **Input data channels(s):** RGB, NIR, VV/VH, etc. Include number of channels.
+- **Input data timesteps:** 1, 12 (monthly), 2 (seasonally), etc.
+- **Projection:** EPSG:4326/...
+- **License:** CC-0/Commercial/...
+- **Data Creation Details:** Publication or other source of information about how dataset was constructed
+
+...
+
+### Dataset splits
+<!-- Include details about the dataset splits, if available. -->
+
+**Type of split:** e.g., uniform at random, geographically-partitioned, etc.
+
+| Subset | # samples |
+| ----- | -------- |
+| Train | integer |
+| Validation | integer |
+| Test | integer |
+
+### SOTA performance
+
+<!-- If the dataset was published with state-of-the-art (SOTA) performance for benchmarking, include those metrics here. -->
+
+| Model | F1 score | IoU | mAP |
+| ----- | -------- | --- | --- |
+| name | 0-100 | 0-100 | 0-100 |
+
+### Example
+
+<!-- Please provide a link to the data or embed it into this document as a code block. -->
+
+## API (optional)
+
+<!-- If the dataset provides an API, python package, or other software for loading the dataset, 
+include details about it here. -->
+
+| Library/package | URL | Documentation |
+| -------- | --- | ------------- |
+| Library name | https://data.example/api/ | https://data.example/api/docs/ |
+
+### Example
+
+<!-- Please provide a link to the data or embed it into this document as a code block. -->


### PR DESCRIPTION
We are surveying two main types of datasets:
1. Field boundary vector datasets: ground-truth, ML-generated, etc described by `template.md`
2. ML benchmark datasets: these datasets are used for training and evaluating/comparing (benchmarking) ML methods for field boundary delineation. They typically include a rasterized/image version of a field boundary polygon dataset (which might be part of 1) paired with corresponding satellite data. These form the data + label pairs for ML model training/eval. I propose to describe these using a different template `template-mlbenchmark.md`

Food for thought:
- At first I tried to add fields to `template.md` for ML benchmark datasets, but it became too clunky because there are many different attributes that one wants to describe for benchmarks that don't apply to the vector polygon datasets. So I made it a separate template.
- Some datasets provide both the ground truth boundaries and a benchmark dataset created using them (e.g., [AI4Boundaries](https://github.com/fiboa/data-survey/blob/main/data/AI4Boundaries.md)). My current idea is to create separate entries for those components of the data (i.e., both 1 and 2 above) and link to 1 in the descriptor for 2 (in the label data source field).

Suggestions/debates welcome!